### PR TITLE
new param ctimeout, updated to hackney 0.4.4

### DIFF
--- a/include/erlastic_search.hrl
+++ b/include/erlastic_search.hrl
@@ -4,5 +4,6 @@
 -record(erls_params, {
           host        = <<"127.0.0.1">> :: binary(),
           port        = 9200 :: integer(),
-          timeout     = infinity :: integer() | infinity
+          timeout     = infinity :: integer() | infinity,
+          ctimeout    = infinity :: integer() | infinity
          }).

--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,6 @@
 {deps_dir, ["deps"]}.
 
 {deps, [
-       {hackney, "0.4.0", {git, "git://github.com/benoitc/hackney.git", {tag, "0.4.0"}}}
+       {hackney, "0.4.4", {git, "git://github.com/benoitc/hackney.git", {tag, "0.4.4"}}}
        ,{jsx, "1.4.1", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v1.4.1"}}}       
        ]}.

--- a/src/erls_resource.erl
+++ b/src/erls_resource.erl
@@ -55,11 +55,11 @@ request(State, Method, Path, Headers, Params, Body, Options) ->
              do_request(State, Method, Path1, Headers, <<>>, Options)
      end.
 
-do_request(#erls_params{host=Host, port=Port, timeout=Timeout},
+do_request(#erls_params{host=Host, port=Port, timeout=Timeout, ctimeout=CTimeout},
            Method, Path, Headers, Body, Options) ->
     case hackney:request(Method, <<Host/binary, ":", (list_to_binary(integer_to_list(Port)))/binary,
                                    "/", Path/binary>>, Headers, Body,
-                         [{recv_timeout, Timeout} | Options]) of
+                         [{recv_timeout, Timeout}, {connect_timeout, CTimeout} | Options]) of
         {ok, Status, _Headers, Client} when Status =:= 200
                                           ; Status =:= 201 ->
             case hackney:body(Client) of


### PR DESCRIPTION
Hello,

I had a use case where elasticsearch was not able to respond to the request (a bad-index situation, but nvm), and connections started to stack up, until the erlang vm crashed because of too many emfile errors (and supervisors reaching the max restart intensity).

Testing a bit using `nc -l 127.0.0.1 9200` (i.e: starting a server that could accept the connection but not serve the response) showed that using **#erls_params.timeout** would not help in that situation (the connections where still being kept open without timing out).

What did work is to use the new hackney option [connection_timeout](https://github.com/benoitc/hackney/commit/17c0f4c6c8f1d66613c7739c05c7bef7b950cf39)  which is in version 0.4.1 (the one in rebar.config is 0.4.0, and i went a bit further, up to 0.4.4).

Hope this is an acceptable update :)

best!
