### PR TITLE
Change dependencies' protocol from git to https

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,6 @@
 {deps_dir, ["deps"]}.
 
 {deps, [
-       {hackney, "0.4.4", {git, "git://github.com/benoitc/hackney.git", {tag, "0.4.4"}}}
-       ,{jsx, "1.4.1", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v1.4.1"}}}       
+       {hackney, "0.4.4", {git, "https://github.com/benoitc/hackney.git", {tag, "0.4.4"}}}
+       ,{jsx, "1.4.1", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v1.4.1"}}}       
        ]}.


### PR DESCRIPTION
Some servers behind firewall will only support http/https but not git
protocol due to company security policy
