### PR TITLE
hackney:request can also return {error, ...}

### DIFF
--- a/src/erls_resource.erl
+++ b/src/erls_resource.erl
@@ -81,7 +81,9 @@ do_request(#erls_params{host=Host, port=Port, timeout=Timeout, ctimeout=CTimeout
                     Error
             end;
         {ok, Status, _Headers, _Client} ->
-            {error, Status}
+            {error, Status};
+        {error, R} ->
+            {error, R}
     end.
 
 encode_query(Props) ->


### PR DESCRIPTION
This fixes crashes when trying to do elasticsearch queries when e.g. the host is down.
