### PR TITLE
returning elasticsearch errors

### DIFF
--- a/src/erls_resource.erl
+++ b/src/erls_resource.erl
@@ -80,8 +80,11 @@ do_request(#erls_params{host=Host, port=Port, timeout=Timeout, ctimeout=CTimeout
                 {error, _Reason} = Error ->
                     Error
             end;
-        {ok, Status, _Headers, _Client} ->
-            {error, Status};
+        {ok, Status, _Headers, Client} ->
+            case hackney:body(Client) of
+                {ok, RespBody, _Client1} -> {error, {Status, jsx:decode(RespBody)}};
+                {error, _Reason} -> {error, Status}
+            end;
         {error, R} ->
             {error, R}
     end.


### PR DESCRIPTION
Hello :) 

I ran into an issue related to a bad formed query, and I could not see the error sent by elasticsearch. This patch allows the caller to get the actual error sent by elasticsearch, and it seems to be more useful this way.

Thoughts?

Cheers!
