### PR TITLE
allowing payload for methods like DELETE.

### DIFF
--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -34,6 +34,8 @@
         ,delete_doc/4
         ,delete_doc_by_query/3
         ,delete_doc_by_query/4
+        ,delete_doc_by_query_doc/3
+        ,delete_doc_by_query_doc/4
         ,optimize_index/1
         ,optimize_index/2]).
 
@@ -203,6 +205,15 @@ delete_doc_by_query(Index, Type, Query) ->
 
 delete_doc_by_query(Params, Index, Type, Query) ->
     erls_resource:delete(Params, filename:join([Index, Type]), [], [{<<"q">>, Query}], Params#erls_params.http_client_options).
+
+delete_doc_by_query_doc(Index, Type, Doc) ->
+    delete_doc_by_query_doc(#erls_params{}, Index, Type, Doc).
+
+delete_doc_by_query_doc(Params, Index, any, Doc) ->
+    erls_resource:delete(Params, filename:join([Index, <<"_query">>]), [], [], jsx:encode(Doc), Params#erls_params.http_client_options);
+
+delete_doc_by_query_doc(Params, Index, Type, Doc) ->
+    erls_resource:delete(Params, filename:join([Index, Type, <<"_query">>]), [], [], jsx:encode(Doc), Params#erls_params.http_client_options).
 
 optimize_index(Index) ->
     optimize_index(#erls_params{}, Index).


### PR DESCRIPTION
Hello again :)

In its delete_by_query api, elasticsearch allows the query to be passed in the query string, but also as a json payload. This should allow that, and also does some cleanup, by treating the absence of a payload as a payload of 0 size (content-length).

Any thoughts?
