### PR TITLE
adding support for percolator feature

### DIFF
--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -40,6 +40,8 @@
         ,optimize_index/2
         ,percolator_add/3
         ,percolator_add/4
+        ,percolator_del/2
+        ,percolator_del/3
         ,percolate/3
         ,percolate/4]).
 
@@ -230,6 +232,12 @@ percolator_add(Index, Name, Query) ->
 
 percolator_add(Params, Index, Name, Query) ->
     erls_resource:put(Params, filename:join([<<"_percolator">>, commas(Index), Name]), [], [], jsx:encode(Query), Params#erls_params.http_client_options).
+
+percolator_del(Index, Name) ->
+    percolator_del(#erls_params{}, Index, Name).
+
+percolator_del(Params, Index, Name) ->
+    erls_resource:delete(Params, filename:join([<<"_percolator">>, commas(Index), Name]), [], [], [], Params#erls_params.http_client_options).
 
 percolate(Index, Type, Doc) ->
     percolate(#erls_params{}, Index, Type, Doc).


### PR DESCRIPTION
Hello :)

This adds support for [the percolator feature](http://www.elasticsearch.org/blog/percolator/), so queries can be added and docs can be percolated. Another useful change would be to let the index and index_bulk operations percolate the docs when indexing, that's for another pull :)
