### PR TITLE
Upgrade hackney to 0.11.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,6 @@
 {deps_dir, ["deps"]}.
 
 {deps, [
-       {hackney, "0.4.4", {git, "https://github.com/benoitc/hackney.git", {tag, "0.4.4"}}}
+       {hackney, "0.11.1", {git, "https://github.com/benoitc/hackney.git", {tag, "0.11.1"}}}
        ,{jsx, "1.4.1", {git, "https://github.com/talentdeficit/jsx.git", {tag, "v1.4.1"}}}       
        ]}.

--- a/src/erlastic_search.app.src
+++ b/src/erlastic_search.app.src
@@ -2,7 +2,7 @@
 %% application.
 {application, erlastic_search, 
   [{description, "An Erlang app for communicating with Elastic Search's rest interface."},
-   {vsn, "0.3.0"},
+   {vsn, "0.3.1"},
    {modules, []},
    {registered,[]},
    {applications, [kernel

--- a/src/erls_resource.erl
+++ b/src/erls_resource.erl
@@ -70,7 +70,7 @@ do_request(#erls_params{host=Host, port=Port, timeout=Timeout, ctimeout=CTimeout
         {ok, Status, _Headers, Client} when Status =:= 200
                                           ; Status =:= 201 ->
             case hackney:body(Client) of
-                {ok, RespBody, _Client1} ->
+                {ok, RespBody} ->
                     {ok, jsx:decode(RespBody)};
                 {error, _Reason} = Error ->
                     Error
@@ -99,4 +99,5 @@ default_content_length(B, H) ->
 
 make_body(Body, Headers, Options) ->
     {default_content_length(Body, Headers), Options, Body}.
+
 


### PR DESCRIPTION
erlastic_search still uses 0.4.4 which has connection pooling issues (causing emfile errors); upgrading hackney to latest version seems to fix this.
