### PR TITLE
Elasticsearch is always in the foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Testing
 First start a local Elasticsearch:
 
 ```bash
-$ bin/elasticsearch -f
+$ bin/elasticsearch
 ```
 
 Run Common Test:


### PR DESCRIPTION
From the changelog for version 1.0 :

`Elasticsearch now runs in the foreground by default. There is no more -f flag on the command line.`

https://www.elastic.co/guide/en/elasticsearch/reference/master/_system_and_settings.html#_system_and_settings