### PR TITLE
Remove redundant braces for JSON input

### DIFF
--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -197,11 +197,11 @@ upsert_doc_opts(Params, Index, Type, Id, Doc, Opts) when is_list(Doc), is_list(O
 bulk_index_docs(Params, IndexTypeIdJsonTuples) ->
     Body = lists:map(fun({Index, Type, Id, Doc}) when is_binary(Doc) ->
                              Header = jsx:encode([
-                                                  {<<"index">>, [{[
+                                                  {<<"index">>, [
                                                                   {<<"_index">>, Index},
                                                                   {<<"_type">>, Type},
                                                                   {<<"_id">>, Id}
-                                                                  ]}]}]),
+                                                                  ]}]),
                              [Header, <<"\n">>, Doc, <<"\n">>];
                         ({Index, Type, Id, Doc}) when is_list(Doc) ->
                              Header = jsx:encode([


### PR DESCRIPTION
The proplist representing the header JSON in the first branch of 'bulk_index_docs' contains a redundant set of braces, causing jsx to throw an exception when it attempts to encode the structure. Modify the proplist to match the format expected by jsx.