### PR TITLE
Allowing asynchronous ES queries

### DIFF
--- a/include/erlastic_search.hrl
+++ b/include/erlastic_search.hrl
@@ -1,6 +1,9 @@
 -type header() :: {binary(), binary()}.
 -type headers() :: [header()].
 -type erlastic_json() :: tuple() | list().
+%% Hackney async references actually are just that, references... but it seems
+%% to be an undocumented implementation detail; doc (and specs) only says `any()'
+-type erlastic_success_result() :: erlastic_json() | {async, HackneyRef :: any()}.
 
 -record(erls_params, {
           host        = <<"127.0.0.1">> :: binary(),

--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -66,7 +66,7 @@
 %% Elasticsearch, the default settings on localhost.
 %% @end
 %%--------------------------------------------------------------------
--spec create_index(binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec create_index(binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 create_index(Index) ->
     create_index(#erls_params{}, Index).
 
@@ -76,7 +76,7 @@ create_index(Index) ->
 %% details to create and sends the request to Elasticsearch.
 %% @end
 %%--------------------------------------------------------------------
--spec create_index(#erls_params{}, binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec create_index(#erls_params{}, binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 create_index(Params, Index) ->
     erls_resource:put(Params, Index, [], [], [], Params#erls_params.http_client_options).
 
@@ -108,15 +108,15 @@ stats_index(Params, Index) ->
 %% @end
 %%--------------------------------------------------------------------
 
--spec nodes_info() -> {ok, erlastic_json()} | {error, any()}.
+-spec nodes_info() -> {ok, erlastic_success_result()} | {error, any()}.
 nodes_info() ->
     nodes_info(#erls_params{}).
 
--spec nodes_info(#erls_params{}) -> {ok, erlastic_json()} | {error, any()}.
+-spec nodes_info(#erls_params{}) -> {ok, erlastic_success_result()} | {error, any()}.
 nodes_info(#erls_params{} = Params) ->
     nodes_info(Params, []).
 
--spec nodes_info(#erls_params{}, [binary()]) -> {ok, erlastic_json()} | {error, any()}.
+-spec nodes_info(#erls_params{}, [binary()]) -> {ok, erlastic_success_result()} | {error, any()}.
 nodes_info(#erls_params{} = Params, Nodes) when erlang:is_list(Nodes) ->
     erls_resource:get(Params, filename:join("_nodes", commas(Nodes)), [], [],
                       Params#erls_params.http_client_options).
@@ -126,11 +126,11 @@ nodes_info(#erls_params{} = Params, Nodes) when erlang:is_list(Nodes) ->
 %% Insert a mapping into an Elasticsearch index
 %% @end
 %%--------------------------------------------------------------------
--spec put_mapping(binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec put_mapping(binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 put_mapping(Index, Type, Doc) ->
     put_mapping(#erls_params{}, Index, Type, Doc).
 
--spec put_mapping(#erls_params{}, binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec put_mapping(#erls_params{}, binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 put_mapping(Params, Index, Type, Doc) when is_list(Doc); is_tuple(Doc) ->
     put_mapping(Params, Index, Type, erls_json:encode(Doc));
 put_mapping(Params, Index, Type, Doc) when is_binary(Doc) ->
@@ -143,11 +143,11 @@ put_mapping(Params, Index, Type, Doc) when is_binary(Doc) ->
 %% default server. Elasticsearch provides the doc with an id.
 %% @end
 %%--------------------------------------------------------------------
--spec index_doc(binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec index_doc(binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 index_doc(Index, Type, Doc) ->
     index_doc(#erls_params{}, Index, Type, Doc).
 
--spec index_doc(#erls_params{}, binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec index_doc(#erls_params{}, binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 index_doc(Params, Index, Type, Doc) when is_list(Doc); is_tuple(Doc) ->
     index_doc(Params, Index, Type, erls_json:encode(Doc));
 index_doc(Params, Index, Type, Doc) when is_binary(Doc) ->
@@ -160,15 +160,15 @@ index_doc(Params, Index, Type, Doc) when is_binary(Doc) ->
 %% and passes to the default server.
 %% @end
 %%--------------------------------------------------------------------
--spec index_doc_with_id(binary(), binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec index_doc_with_id(binary(), binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 index_doc_with_id(Index, Type, Id, Doc) ->
     index_doc_with_id_opts(#erls_params{}, Index, Type, Id, Doc, []).
 
--spec index_doc_with_id(#erls_params{}, binary(), binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec index_doc_with_id(#erls_params{}, binary(), binary(), binary(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 index_doc_with_id(Params, Index, Type, Id, Doc) ->
     index_doc_with_id_opts(Params, Index, Type, Id, Doc, []).
 
--spec index_doc_with_id_opts(#erls_params{}, binary(), binary(), binary(), erlastic_json() | binary(), list()) -> {ok, erlastic_json()} | {error, any()}.
+-spec index_doc_with_id_opts(#erls_params{}, binary(), binary(), binary(), erlastic_json() | binary(), list()) -> {ok, erlastic_success_result()} | {error, any()}.
 index_doc_with_id_opts(Params, Index, Type, Id, Doc, Opts) when is_list(Opts), (is_list(Doc) orelse is_tuple(Doc)) ->
     index_doc_with_id_opts(Params, Index, Type, Id, erls_json:encode(Doc), Opts);
 index_doc_with_id_opts(Params, Index, Type, Id, Doc, Opts) when is_binary(Doc), is_list(Opts) ->
@@ -180,15 +180,15 @@ index_doc_with_id_opts(Params, Index, Type, Id, Doc, Opts) when is_binary(Doc), 
 %% (https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html)
 %% --------------------------------------------------------------------
 
--spec upsert_doc(binary(), binary(), binary(), erlastic_json()) -> {ok, erlastic_json()} | {error, any()}.
+-spec upsert_doc(binary(), binary(), binary(), erlastic_json()) -> {ok, erlastic_success_result()} | {error, any()}.
 upsert_doc(Index, Type, Id, Doc) ->
     upsert_doc_opts(#erls_params{}, Index, Type, Id, Doc, []).
 
--spec upsert_doc(#erls_params{}, binary(), binary(), binary(), erlastic_json()) -> {ok, erlastic_json()} | {error, any()}.
+-spec upsert_doc(#erls_params{}, binary(), binary(), binary(), erlastic_json()) -> {ok, erlastic_success_result()} | {error, any()}.
 upsert_doc(Params, Index, Type, Id, Doc) ->
     upsert_doc_opts(Params, Index, Type, Id, Doc, []).
 
--spec upsert_doc_opts(#erls_params{}, binary(), binary(), binary(), erlastic_json(), list()) -> {ok, erlastic_json()} | {error, any()}.
+-spec upsert_doc_opts(#erls_params{}, binary(), binary(), binary(), erlastic_json(), list()) -> {ok, erlastic_success_result()} | {error, any()}.
 upsert_doc_opts(Params, Index, Type, Id, Doc, Opts) when is_list(Opts), (is_list(Doc) orelse is_tuple(Doc)) ->
     DocBin = erls_json:encode(Doc),
     %% we cannot use erls_json to generate this, see the doc string for `erls_json:encode/1'
@@ -198,7 +198,7 @@ upsert_doc_opts(Params, Index, Type, Id, Doc, Opts) when is_list(Opts), (is_list
                        Params#erls_params.http_client_options).
 
 %% Documents is [ {Index, Type, Id, Json}, ... ]
--spec bulk_index_docs(#erls_params{}, list()) -> {ok, erlastic_json()} | {error, any()}.
+-spec bulk_index_docs(#erls_params{}, list()) -> {ok, erlastic_success_result()} | {error, any()}.
 bulk_index_docs(Params, IndexTypeIdJsonTuples) ->
     Body = lists:map(fun({Index, Type, Id, Doc}) when is_binary(Doc) ->
                              Header = bulk_index_docs_header(Index, Type, Id),
@@ -215,21 +215,21 @@ bulk_index_docs(Params, IndexTypeIdJsonTuples) ->
 %% it to the Elasticsearch server specified in Params.
 %% @end
 %%--------------------------------------------------------------------
--spec search(binary() | list(), erlastic_json() | binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec search(binary() | list(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 search(Index, Query) ->
     search(#erls_params{}, Index, <<>>, Query, []).
 
--spec search(binary() | list() | #erls_params{}, binary() | list(), erlastic_json() | binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec search(binary() | list() | #erls_params{}, binary() | list(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 search(Params, Index, Query) when is_record(Params, erls_params) ->
     search(Params, Index, <<>>, Query, []);
 search(Index, Type, Query) ->
     search(#erls_params{}, Index, Type, Query, []).
 
--spec search_limit(binary() | list(), binary(), erlastic_json() | binary(), integer()) -> {ok, erlastic_json()} | {error, any()}.
+-spec search_limit(binary() | list(), binary(), erlastic_json() | binary(), integer()) -> {ok, erlastic_success_result()} | {error, any()}.
 search_limit(Index, Type, Query, Limit) when is_integer(Limit) ->
     search(#erls_params{}, Index, Type, Query, [{<<"size">>, integer_to_list(Limit)}]).
 
--spec search(#erls_params{}, list() | binary(), list() | binary(), erlastic_json() | binary(), list()) -> {ok, erlastic_json()} | {error, any()}.
+-spec search(#erls_params{}, list() | binary(), list() | binary(), erlastic_json() | binary(), list()) -> {ok, erlastic_success_result()} | {error, any()}.
 search(Params, Index, Type, Query, Opts) when is_binary(Query) ->
     erls_resource:get(Params, filename:join([commas(Index), Type, <<"_search">>]), [], [{<<"q">>, Query}]++Opts, Params#erls_params.http_client_options);
 search(Params, Index, Type, Query, Opts) ->
@@ -241,7 +241,7 @@ search(Params, Index, Type, Query, Opts) ->
 %% it to the default Elasticsearch server on localhost:9100
 %% @end
 %%--------------------------------------------------------------------
--spec get_doc(binary(), binary(), binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec get_doc(binary(), binary(), binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 get_doc(Index, Type, Id) ->
     get_doc(#erls_params{}, Index, Type, Id).
 
@@ -251,7 +251,7 @@ get_doc(Index, Type, Id) ->
 %% it to the Elasticsearch server specified in Params.
 %% @end
 %%--------------------------------------------------------------------
--spec get_doc(#erls_params{}, binary(), binary(), binary()) -> {ok, erlastic_json()} | {error, any()}.
+-spec get_doc(#erls_params{}, binary(), binary(), binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 get_doc(Params, Index, Type, Id) ->
     erls_resource:get(Params, filename:join([Index, Type, Id]), [], [], Params#erls_params.http_client_options).
 

--- a/src/erls_resource.erl
+++ b/src/erls_resource.erl
@@ -80,6 +80,11 @@ do_request(#erls_params{host=Host, port=Port, timeout=Timeout, ctimeout=CTimeout
                 {ok, RespBody} -> {error, {Status, erls_json:decode(RespBody)}};
                 {error, _Reason} -> {error, Status}
             end;
+        {ok, ClientRef} ->
+            %% that's when the options passed to hackney included `async'
+            %% this reference can then be used to match the messages from
+            %% hackney when ES replies; see the hackney doc for more information
+            {ok, {async, ClientRef}};
         {error, R} ->
             {error, R}
     end.


### PR DESCRIPTION
Using hackney's option `async`