### PR TITLE
the app should not depend on jsx app

### DIFF
--- a/src/erlastic_search.app.src
+++ b/src/erlastic_search.app.src
@@ -3,7 +3,7 @@
               {vsn,"git"},
               {modules,[]},
               {registered,[]},
-              {applications,[kernel,stdlib,ssl,hackney,jsx]},
+              {applications,[kernel,stdlib,ssl,hackney]},
               {start_phases,[]},
               {maintainers,["Tristan Sloughter"]},
               {licenses,["LGPL"]},


### PR DESCRIPTION
It's probably safer to let the user have a json app of their own started before erlastic_search, especially if not using jsx at all.