### PR TITLE
Introduce get_doc_opts/5 as an equivalent to get_doc/4 including options

### DIFF
--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -33,6 +33,7 @@
         ,search_limit/4
         ,get_doc/3
         ,get_doc/4
+        ,get_doc_opts/5
         ,flush_index/1
         ,flush_index/2
         ,flush_all/0
@@ -253,7 +254,12 @@ get_doc(Index, Type, Id) ->
 %%--------------------------------------------------------------------
 -spec get_doc(#erls_params{}, binary(), binary(), binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 get_doc(Params, Index, Type, Id) ->
-    erls_resource:get(Params, filename:join([Index, Type, Id]), [], [], Params#erls_params.http_client_options).
+    get_doc_opts(Params, Index, Type, Id, []).
+
+-spec get_doc_opts(#erls_params{}, binary(), binary(), binary(), list()) -> {ok, erlastic_success_result()}
+                                                                          | {error, any()}.
+get_doc_opts(Params, Index, Type, Id, Opts) ->
+    erls_resource:get(Params, filename:join([Index, Type, Id]), [], Opts, Params#erls_params.http_client_options).
 
 flush_index(Index) ->
     flush_index(#erls_params{}, Index).


### PR DESCRIPTION
This introduces `get_doc_opts/5` by following the example of `index_doc_with_id_opts/6`, `upsert_doc_opts/6` by extending `get_doc/4` to support additional options.