### PR TITLE
Add functionality to retrieve index templates

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,7 @@
-[{<<"hackney">>,{pkg,<<"hackney">>,<<"1.6.3">>},0},
+[{<<"certifi">>,{pkg,<<"certifi">>,<<"0.7.0">>},1},
+ {<<"hackney">>,{pkg,<<"hackney">>,<<"1.6.3">>},0},
  {<<"idna">>,{pkg,<<"idna">>,<<"1.0.2">>},1},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.6.2">>},0},
- {<<"ssl_verify_hostname">>,{pkg,<<"ssl_verify_hostname">>,<<"1.0.5">>},1}].
+ {<<"metrics">>,{pkg,<<"metrics">>,<<"1.0.1">>},1},
+ {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.0.2">>},1},
+ {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.1">>},1}].

--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -26,8 +26,9 @@
         ,get_settings/0
         ,get_settings/1
         ,get_settings/2
-        ,get_template_mapping_and_settings/1
-        ,get_template_mapping_and_settings/2
+        ,get_templates/0
+        ,get_templates/1
+        ,get_templates/2
         ,index_doc/3
         ,index_doc/4
         ,index_doc_with_opts/5
@@ -249,24 +250,36 @@ get_settings(#erls_params{} = Params, Index) when is_binary(Index) ->
 
 %%--------------------------------------------------------------------
 %% @doc
-%% Retrieves the mapping and settings for the given index template, using the default server
-%% parameters. See docs at:
+%% Retrieves all index templates, using the default server parameters. See docs at:
 %% https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#getting
 %% @end
 %%--------------------------------------------------------------------
--spec get_template_mapping_and_settings(binary()) -> {ok, erlastic_success_result()} | {error, any()}.
-get_template_mapping_and_settings(IndexTemplate) ->
-    get_template_mapping_and_settings(#erls_params{}, IndexTemplate).
+-spec get_templates() -> {ok, erlastic_success_result()} | {error, any()}.
+get_templates() ->
+    get_templates(#erls_params{}, <<>>).
 
 %%--------------------------------------------------------------------
 %% @doc
-%% Retrieves the mapping and settings for the given index template, using the provided server
+%% Retrieves the index templates that match the index template string, using the default server parameters
+%% or retrieves all index templates with provided server parameters. See docs at:
+%% https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#getting
+%% @end
+%%--------------------------------------------------------------------
+-spec get_templates(binary() | #erls_params{}) -> {ok, erlastic_success_result()} | {error, any()}.
+get_templates(IndexTemplate) when is_binary(IndexTemplate) ->
+    get_templates(#erls_params{}, IndexTemplate);
+get_templates(#erls_params{} = Params) ->
+    get_templates(Params, <<>>).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Retrieves the index templates that match the index template string, using the provided server
 %% parameters. See docs at:
 %% https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#getting
 %% @end
 %%--------------------------------------------------------------------
--spec get_template_mapping_and_settings(#erls_params{}, binary()) -> {ok, erlastic_success_result()} | {error, any()}.
-get_template_mapping_and_settings(#erls_params{http_client_options = HttpClientOptions} = Params, IndexTemplate) ->
+-spec get_templates(#erls_params{}, binary()) -> {ok, erlastic_success_result()} | {error, any()}.
+get_templates(#erls_params{http_client_options = HttpClientOptions} = Params, IndexTemplate) ->
     erls_resource:get(Params, filename:join([<<"_template">>, IndexTemplate]), [], [], [], HttpClientOptions).
 
 %%--------------------------------------------------------------------

--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -26,6 +26,8 @@
         ,get_settings/0
         ,get_settings/1
         ,get_settings/2
+        ,get_template_mapping_and_settings/1
+        ,get_template_mapping_and_settings/2
         ,index_doc/3
         ,index_doc/4
         ,index_doc_with_opts/5
@@ -244,6 +246,28 @@ get_settings(Index) when is_binary(Index) ->
 -spec get_settings(#erls_params{}, binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 get_settings(#erls_params{} = Params, Index) when is_binary(Index) ->
     erls_resource:get(Params, filename:join([Index, <<"_settings">>]), [], [], [], Params#erls_params.http_client_options).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Retrieves the mapping and settings for the given index template, using the default server
+%% parameters. See docs at:
+%% https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#getting
+%% @end
+%%--------------------------------------------------------------------
+-spec get_template_mapping_and_settings(binary()) -> {ok, erlastic_success_result()} | {error, any()}.
+get_template_mapping_and_settings(IndexTemplate) ->
+    get_template_mapping_and_settings(#erls_params{}, IndexTemplate).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Retrieves the mapping and settings for the given index template, using the provided server
+%% parameters. See docs at:
+%% https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#getting
+%% @end
+%%--------------------------------------------------------------------
+-spec get_template_mapping_and_settings(#erls_params{}, binary()) -> {ok, erlastic_success_result()} | {error, any()}.
+get_template_mapping_and_settings(#erls_params{http_client_options = HttpClientOptions} = Params, IndexTemplate) ->
+    erls_resource:get(Params, filename:join([<<"_template">>, IndexTemplate]), [], [], [], HttpClientOptions).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -11,6 +11,8 @@
 -export([create_index/1
         ,create_index/2
         ,create_index/3
+        ,create_index_template/2
+        ,create_index_template/3
         ,stats_index/0
         ,stats_index/1
         ,stats_index/2
@@ -26,9 +28,9 @@
         ,get_settings/0
         ,get_settings/1
         ,get_settings/2
-        ,get_templates/0
-        ,get_templates/1
-        ,get_templates/2
+        ,get_index_templates/0
+        ,get_index_templates/1
+        ,get_index_templates/2
         ,index_doc/3
         ,index_doc/4
         ,index_doc_with_opts/5
@@ -65,6 +67,8 @@
         ,delete_doc_by_query_doc/4
         ,delete_index/1
         ,delete_index/2
+        ,delete_index_template/1
+        ,delete_index_template/2
         ,index_exists/1
         ,index_exists/2
         ,optimize_index/1
@@ -112,6 +116,27 @@ create_index(Index, Doc) when is_binary(Index), (is_binary(Doc) orelse is_list(D
 -spec create_index(#erls_params{}, binary(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 create_index(Params, Index, Doc) when is_binary(Index), (is_binary(Doc) orelse is_list(Doc) orelse is_tuple(Doc) orelse is_map(Doc)) ->
     erls_resource:put(Params, Index, [], [], maybe_encode_doc(Doc), Params#erls_params.http_client_options).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Takes the name of an index and a body to use in the request; and
+%% creates an index template using the default settings on localhost.
+%% (see the doc at https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#indices-templates)
+%% @end
+%%--------------------------------------------------------------------
+-spec create_index_template(Index :: binary(), Doc :: erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
+create_index_template(Index, Doc) when is_binary(Index), (is_binary(Doc) orelse is_list(Doc) orelse is_tuple(Doc) orelse is_map(Doc)) ->
+    create_index_template(#erls_params{}, Index, Doc).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Takes a record describing the servers details, an index name, and a request body, and creates an index template
+%% (see the doc at https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#indices-templates)
+%% @end
+%%--------------------------------------------------------------------
+-spec create_index_template(#erls_params{}, binary(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
+create_index_template(Params, Index, Doc) when is_binary(Index), (is_binary(Doc) orelse is_list(Doc) orelse is_tuple(Doc) orelse is_map(Doc)) ->
+    erls_resource:put(Params, <<"_template/", Index/binary>>, [], [], maybe_encode_doc(Doc), Params#erls_params.http_client_options).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -254,9 +279,9 @@ get_settings(#erls_params{} = Params, Index) when is_binary(Index) ->
 %% https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#getting
 %% @end
 %%--------------------------------------------------------------------
--spec get_templates() -> {ok, erlastic_success_result()} | {error, any()}.
-get_templates() ->
-    get_templates(#erls_params{}, <<>>).
+-spec get_index_templates() -> {ok, erlastic_success_result()} | {error, any()}.
+get_index_templates() ->
+    get_index_templates(#erls_params{}, <<>>).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -265,11 +290,11 @@ get_templates() ->
 %% https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#getting
 %% @end
 %%--------------------------------------------------------------------
--spec get_templates(binary() | #erls_params{}) -> {ok, erlastic_success_result()} | {error, any()}.
-get_templates(IndexTemplate) when is_binary(IndexTemplate) ->
-    get_templates(#erls_params{}, IndexTemplate);
-get_templates(#erls_params{} = Params) ->
-    get_templates(Params, <<>>).
+-spec get_index_templates(binary() | #erls_params{}) -> {ok, erlastic_success_result()} | {error, any()}.
+get_index_templates(IndexTemplate) when is_binary(IndexTemplate) ->
+    get_index_templates(#erls_params{}, IndexTemplate);
+get_index_templates(#erls_params{} = Params) ->
+    get_index_templates(Params, <<>>).
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -278,8 +303,8 @@ get_templates(#erls_params{} = Params) ->
 %% https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#getting
 %% @end
 %%--------------------------------------------------------------------
--spec get_templates(#erls_params{}, binary()) -> {ok, erlastic_success_result()} | {error, any()}.
-get_templates(#erls_params{http_client_options = HttpClientOptions} = Params, IndexTemplate) ->
+-spec get_index_templates(#erls_params{}, binary()) -> {ok, erlastic_success_result()} | {error, any()}.
+get_index_templates(#erls_params{http_client_options = HttpClientOptions} = Params, IndexTemplate) ->
     erls_resource:get(Params, filename:join([<<"_template">>, IndexTemplate]), [], [], [], HttpClientOptions).
 
 %%--------------------------------------------------------------------
@@ -488,6 +513,21 @@ delete_index(Index) ->
 delete_index(Params, Index) ->
     erls_resource:delete(Params, Index, [], [], [],
                          Params#erls_params.http_client_options).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Delete existing index template
+%% See docs at: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#delete
+%% @end
+%%--------------------------------------------------------------------
+-spec delete_index_template(binary()) -> {ok, erlastic_success_result()} | {error, any()}.
+delete_index_template(Index) ->
+    delete_index_template(#erls_params{}, Index).
+
+-spec delete_index_template(#erls_params{}, binary()) -> {ok, erlastic_success_result()} | {error, any()}.
+delete_index_template(Params, Index) ->
+    erls_resource:delete(Params, <<"_template/", Index/binary>>, [], [], [],
+        Params#erls_params.http_client_options).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/test/basic_SUITE.erl
+++ b/test/basic_SUITE.erl
@@ -8,7 +8,8 @@
         ,index_encoded_id/1
         ,index_no_id/1
         ,bulk_index_id/1
-        ,search/1]).
+        ,search/1
+        ,index_template_mapping/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -22,7 +23,8 @@ groups() ->
                         ,index_encoded_id
                         ,index_no_id
                         ,bulk_index_id
-                        ,search]}].
+                        ,search
+                        ,index_template_mapping]}].
 
 init_per_group(index_access, Config) ->
     erlastic_search_app:start_deps(),
@@ -70,6 +72,29 @@ search(Config) ->
     IndexName = ?config(index_name, Config),
     {ok, _} = erlastic_search:search(IndexName, <<"hello:there">>).
 
+%% @doc Creates an index template, and tests that it exists with the correct settings and mapping
+index_template_mapping(_Config) ->
+    %% First we create the index template
+    TemplatePath = create_random_name(<<"_template/test_template_">>),
+    {ok, _} = erlastic_search:create_index(TemplatePath, template_mapping_json()),
+
+    %% When searching for an index template, we should only need the name, not the full path
+    %% The get_template_mapping_and_settings/1 fun should handle creating the correct path
+    [_, TemplateName] = binary:split(TemplatePath, <<"_template/">>),
+    {ok, [{TemplateName, ActualTemplateSettingsAndMapping1}]} = erlastic_search:get_template_mapping_and_settings(TemplateName),
+
+    %% The order and aliases are generated automatically, both of which will be default, we will not compare
+    ActualTemplateSettingsAndMapping2 = proplists:delete(<<"order">>, ActualTemplateSettingsAndMapping1),
+    ActualTemplateSettingsAndMapping3 = proplists:delete(<<"aliases">>, ActualTemplateSettingsAndMapping2),
+
+    ExpectedTemplateMappingAndSettings = lists:sort(jsx:decode(jsx:encode(template_mapping_json()))),
+    ActualTemplateSettingsAndMapping = lists:sort(ActualTemplateSettingsAndMapping3),
+
+    ExpectedTemplateMappingAndSettings = ActualTemplateSettingsAndMapping,
+
+    %% Remove this index template
+    erlastic_search:delete_index(TemplatePath).
+
 %%%===================================================================
 %%% Helper Functions
 %%%===================================================================
@@ -77,3 +102,31 @@ search(Config) ->
 create_random_name(Name) ->
     random:seed(os:timestamp()),
     <<Name/binary, (list_to_binary(erlang:integer_to_list(random:uniform(1000000))))/binary>>.
+
+%% @doc Uses the example template settings from
+%% https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#indices-templates
+template_mapping_json() ->
+    #{
+        <<"mappings">> => #{
+            <<"test_type">> => #{
+                <<"_source">> => #{
+                    <<"enabled">> => false
+                },
+                <<"properties">> => #{
+                    <<"host_name">> => #{
+                        <<"type">> => <<"string">>
+                    },
+                    <<"created_at">> => #{
+                        <<"type">> => <<"date">>,
+                        <<"format">> => <<"EEE MMM dd HH:mm:ss Z YYYY">>
+                    }
+                }
+            }
+        },
+        <<"settings">> => #{
+            <<"index">> => #{
+                <<"number_of_shards">> => <<"1">>
+            }
+        },
+        <<"template">> => <<"test_template-*">>
+    }.

--- a/test/basic_SUITE.erl
+++ b/test/basic_SUITE.erl
@@ -79,9 +79,12 @@ index_template_mapping(_Config) ->
     {ok, _} = erlastic_search:create_index(TemplatePath, template_mapping_json()),
 
     %% When searching for an index template, we should only need the name, not the full path
-    %% The get_template_mapping_and_settings/1 fun should handle creating the correct path
+    %% The get_templates/1 fun should handle creating the correct path
     [_, TemplateName] = binary:split(TemplatePath, <<"_template/">>),
-    {ok, [{TemplateName, ActualTemplateSettingsAndMapping1}]} = erlastic_search:get_template_mapping_and_settings(TemplateName),
+    {ok, [{TemplateName, ActualTemplateSettingsAndMapping1}]} = erlastic_search:get_templates(TemplateName),
+
+    %% Also make sure that the get_templates/0 fun returns the same thing as get_templates/1 with the current state
+    {ok, [{TemplateName, ActualTemplateSettingsAndMapping1}]} = erlastic_search:get_templates(),
 
     %% The order and aliases are generated automatically, both of which will be default, we will not compare
     ActualTemplateSettingsAndMapping2 = proplists:delete(<<"order">>, ActualTemplateSettingsAndMapping1),


### PR DESCRIPTION
Adds 3 new funs:

1. `erlastic_search:get_templates()`
2. `erlastic_search:get_templates(TemplateName :: binary() | #erl_params{})`
3. `erlastic_search:get_templates(#erl_params{}, TemplateName :: binary())`

I also needed to update the dependencies for me to be able to run the tests, or even to compile (perhaps this is just an issue with my machine, in which we can revert the rebar.lock update)