### PR TITLE
Introduce new count API functions 'count/*'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _rel
 erl_crash.dump
 logs
 log
+.rebar3

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,18 @@
+{"1.1.0",
 [{<<"certifi">>,{pkg,<<"certifi">>,<<"0.7.0">>},1},
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.6.3">>},0},
  {<<"idna">>,{pkg,<<"idna">>,<<"1.0.2">>},1},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.6.2">>},0},
  {<<"metrics">>,{pkg,<<"metrics">>,<<"1.0.1">>},1},
  {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.0.2">>},1},
- {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.1">>},1}].
+ {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.1">>},1}]}.
+[
+{pkg_hash,[
+ {<<"certifi">>, <<"861A57F3808F7EB0C2D1802AFEAAE0FA5DE813B0DF0979153CBAFCD853ABABAF">>},
+ {<<"hackney">>, <<"D489D7CA2D4323E307BEDC4BFE684323A7BF773ECFD77938F3EE8074E488E140">>},
+ {<<"idna">>, <<"397E3D001C002319DA75759B0A81156BF11849C71D565162436D50020CB7265E">>},
+ {<<"jsx">>, <<"213721E058DA0587A4BCE3CC8A00FF6684CED229C8F9223245C6FF2C88FBAA5A">>},
+ {<<"metrics">>, <<"25F094DEA2CDA98213CECC3AEFF09E940299D950904393B2A29D191C346A8486">>},
+ {<<"mimerl">>, <<"993F9B0E084083405ED8252B99460C4F0563E41729AB42D9074FD5E52439BE88">>},
+ {<<"ssl_verify_fun">>, <<"28A4D65B7F59893BC2C7DE786DEC1E1555BD742D336043FE644AE956C3497FBE">>}]}
+].

--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -44,6 +44,9 @@
         ,search/2
         ,search/3
         ,search/5
+        ,count/2
+        ,count/3
+        ,count/5
         ,search_limit/4
         ,search_scroll/4
         ,search_scroll/1
@@ -405,6 +408,27 @@ search_limit(Index, Type, Query, Limit) when is_integer(Limit) ->
 
 %%--------------------------------------------------------------------
 %% @doc
+%% Uses the count API to execute a query and get the number of matches
+%% for that query. See `search/*' for more details regarding to
+%% query types and the different input parameters.
+%% @end
+%%--------------------------------------------------------------------
+-spec count(binary() | list(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
+count(Index, Query) ->
+    search_helper(<<"_count">>, #erls_params{}, Index, <<>>, Query, []).
+
+-spec count(binary() | list() | #erls_params{}, binary() | list(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
+count(Params, Index, Query) when is_record(Params, erls_params) ->
+    search_helper(<<"_count">>, Params, Index, <<>>, Query, []);
+count(Index, Type, Query) ->
+    search_helper(<<"_count">>, #erls_params{}, Index, Type, Query, []).
+
+-spec count(#erls_params{}, list() | binary(), list() | binary(), erlastic_json() | binary(), list()) -> {ok, erlastic_success_result()} | {error, any()}.
+count(Params, Index, Type, Query, Opts) ->
+    search_helper(<<"_count">>, Params, Index, Type, Query, Opts).
+
+%%--------------------------------------------------------------------
+%% @doc
 %% search_scroll/4 -- Takes the index, type name and search query
 %% sends it to the Elasticsearch server specified in Params.
 %% Returns search results along with scroll id which can be passed
@@ -421,10 +445,8 @@ search_scroll(Query) ->
      erls_resource:post(Params, filename:join([<<"_search">>, <<"scroll">>]), [], [], erls_json:encode(Query), Params#erls_params.http_client_options).
 
 -spec search(#erls_params{}, list() | binary(), list() | binary(), erlastic_json() | binary(), list()) -> {ok, erlastic_success_result()} | {error, any()}.
-search(Params, Index, Type, Query, Opts) when is_binary(Query) ->
-    erls_resource:get(Params, filename:join([commas(Index), Type, <<"_search">>]), [], [{<<"q">>, Query}]++Opts, Params#erls_params.http_client_options);
 search(Params, Index, Type, Query, Opts) ->
-    erls_resource:post(Params, filename:join([commas(Index), Type, <<"_search">>]), [], Opts, erls_json:encode(Query), Params#erls_params.http_client_options).
+    search_helper(<<"_search">>, Params, Index, Type, Query, Opts).
 
 -spec multi_search(#erls_params{}, list({HeaderInformation :: headers(), SearchRequest :: erlastic_json() | binary()})) -> {ok, ResultJson :: erlastic_success_result()} | {error, Reason :: any()}.
 multi_search(Params, HeaderJsonTuples) ->
@@ -579,6 +601,12 @@ percolate(Params, Index, Type, Doc) ->
     erls_resource:get(Params, filename:join([commas(Index), Type, <<"_percolate">>]), [], [], erls_json:encode(Doc), Params#erls_params.http_client_options).
 
 %%% Internal functions
+
+-spec search_helper(binary(), #erls_params{}, list() | binary(), list() | binary(), erlastic_json() | binary(), list()) -> {ok, erlastic_success_result()} | {error, any()}.
+search_helper(Endpoint, Params, Index, Type, Query, Opts) when is_binary(Query) ->
+    erls_resource:get(Params, filename:join([commas(Index), Type, Endpoint]), [], [{<<"q">>, Query}]++Opts, Params#erls_params.http_client_options);
+search_helper(Endpoint, Params, Index, Type, Query, Opts) ->
+    erls_resource:post(Params, filename:join([commas(Index), Type, Endpoint]), [], Opts, erls_json:encode(Query), Params#erls_params.http_client_options).
 
 -spec commas(list(binary()) | binary()) -> binary().
 commas(Bin) when is_binary(Bin) ->

--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -415,13 +415,13 @@ search_limit(Index, Type, Query, Limit) when is_integer(Limit) ->
 %%--------------------------------------------------------------------
 -spec count(binary() | list(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 count(Index, Query) ->
-    search_helper(<<"_count">>, #erls_params{}, Index, <<>>, Query, []).
+    count(#erls_params{}, Index, <<>>, Query, []).
 
 -spec count(binary() | list() | #erls_params{}, binary() | list(), erlastic_json() | binary()) -> {ok, erlastic_success_result()} | {error, any()}.
 count(Params, Index, Query) when is_record(Params, erls_params) ->
-    search_helper(<<"_count">>, Params, Index, <<>>, Query, []);
+    count(Params, Index, <<>>, Query, []);
 count(Index, Type, Query) ->
-    search_helper(<<"_count">>, #erls_params{}, Index, Type, Query, []).
+    count(#erls_params{}, Index, Type, Query, []).
 
 -spec count(#erls_params{}, list() | binary(), list() | binary(), erlastic_json() | binary(), list()) -> {ok, erlastic_success_result()} | {error, any()}.
 count(Params, Index, Type, Query, Opts) ->


### PR DESCRIPTION
The new `count/*` functions do behave in the same way as the `search/*` functions except for using a different endpoint `_search`/`_count`, therefor they do provide the same interface. You can find the documentation for the count API [here](https://www.elastic.co/guide/en/elasticsearch/reference/5.2/search-count.html).

Relates to #54.