### PR TITLE
Add content-type to requests to elasticsearch

### DIFF
--- a/src/erls_resource.erl
+++ b/src/erls_resource.erl
@@ -48,7 +48,8 @@ request(State, Method, Path, Headers, Params, Body, Options) ->
                   Props -> <<"?", (encode_query(Props))/binary>>
               end)/binary>>,
     {Headers2, Options1, Body} = make_body(Body, Headers, Options),
-    do_request(State, Method, Path1, Headers2, Body, Options1).
+    Headers3 = default_header(<<"Content-Type">>, <<"application/json">>, Headers2),
+    do_request(State, Method, Path1, Headers3, Body, Options1).
 
 do_request(#erls_params{host=Host, port=Port, timeout=Timeout, ctimeout=CTimeout},
            Method, Path, Headers, Body, Options) ->


### PR DESCRIPTION
To remove the `Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header.` warning displayed in recent versions of elasticsearch.