### PR TITLE
Deprecate all usage of jsx module

### DIFF
--- a/src/erlastic_search.erl
+++ b/src/erlastic_search.erl
@@ -486,7 +486,7 @@ search(Params, Index, Type, Query, Opts) ->
 -spec multi_search(#erls_params{}, list({HeaderInformation :: headers(), SearchRequest :: erlastic_json() | binary()})) -> {ok, ResultJson :: erlastic_success_result()} | {error, Reason :: any()}.
 multi_search(Params, HeaderJsonTuples) ->
     Body = lists:map(fun({HeaderInformation, SearchRequest}) ->
-        [ jsx:encode(HeaderInformation), <<"\n">>, maybe_encode_doc(SearchRequest), <<"\n">> ]
+        [ erls_json:encode(HeaderInformation), <<"\n">>, maybe_encode_doc(SearchRequest), <<"\n">> ]
     end, HeaderJsonTuples),
     erls_resource:get(Params, <<"/_msearch">>, [], [], iolist_to_binary(Body), Params#erls_params.http_client_options).
 
@@ -740,7 +740,7 @@ build_header(Operation, Index, Type, Id, HeaderInformation) ->
                 false -> [{<<"_id">>, Id} | Header1]
               end,
 
-    [jsx:encode([{erlang:atom_to_binary(Operation, utf8), Header2}])].
+    [erls_json:encode([{erlang:atom_to_binary(Operation, utf8), Header2}])].
 
 build_body(delete, no_body) ->
     [<<"\n">>];

--- a/test/basic_SUITE.erl
+++ b/test/basic_SUITE.erl
@@ -89,7 +89,7 @@ index_templates(_Config) ->
     ActualTemplateSettingsAndMapping2 = proplists:delete(<<"order">>, ActualTemplateSettingsAndMapping1),
     ActualTemplateSettingsAndMapping3 = proplists:delete(<<"aliases">>, ActualTemplateSettingsAndMapping2),
 
-    ExpectedTemplateMappingAndSettings = lists:sort(jsx:decode(jsx:encode(template_mapping_json()))),
+    ExpectedTemplateMappingAndSettings = lists:sort(erls_json:decode(erls_json:encode(template_mapping_json()))),
     ActualTemplateSettingsAndMapping = lists:sort(ActualTemplateSettingsAndMapping3),
 
     ExpectedTemplateMappingAndSettings = ActualTemplateSettingsAndMapping,


### PR DESCRIPTION
This PR deprecates all usage of the `jsx` module. It's not completely clear why these lines had `jsx` hardcoded in them. My suspicions are that it was meant to protect against other JSON parsers having slightly different implementations (maybe due to ambiguity in the JSON spec).

However, using `erls_json` everywhere would benefit us since it would allow projects to completely ditch `jsx` instead of forcefully keeping in the dependencies tree.